### PR TITLE
Versiuon 3.6.9

### DIFF
--- a/OsanoConsentManagerSDK/3.6.9/OsanoConsentManagerSDK.podspec
+++ b/OsanoConsentManagerSDK/3.6.9/OsanoConsentManagerSDK.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'OsanoConsentManagerSDK'
+    s.version      = '3.6.9'
+    s.summary      = 'Osano Consent Manager SDK for iOS'
+    s.homepage     = 'https://osano.com'
+    s.license      = { :type => 'Copyright', :text => 'Copyright (C) Osano, Inc., a Public Benefit Corporation - All Rights Reserved'  }
+    s.author       = { 'Osano' => 'info@osano.com' }
+    s.source       = { :http => 'https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.9.zip' }
+    s.vendored_frameworks = 'ConsentSDK.xcframework'
+    s.platform = :ios
+    s.ios.deployment_target  = '12.1'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "ConsentSDK",
-            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.8.zip",
-            checksum: "5919afe842b111545be9b154ee4a5295c6a364ac4f05b7b9c972894cb4920a3c"
+            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.9.zip",
+            checksum: "ae50a5acdba1c76e7b2b67df778653a6f403b071e73e6d51c623c55b27b4e563"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ source "https://github.com/osano/cocoapods-specs.git"
 Within your `target` add the `OsanoConsentManagerSDK` and version as a referenced pod.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '~> 3.6.7'
+pod 'OsanoConsentManagerSDK', '~> 3.6.9'
 ```
 
 By using a `~>` in front of your version number, you can automatically update to the most recently released major version. If you would rather specify your SDK version, omit the `~>` in front of the version number.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '3.6.7'
+pod 'OsanoConsentManagerSDK', '3.6.9'
 ```
 
 Your project's `Podfile` should look similar to the one below.
@@ -31,6 +31,6 @@ platform :ios, '12.1'
 source "https://github.com/osano/cocoapods-specs.git"
 target 'MyApp' do
  use_frameworks!
- pod 'OsanoConsentManagerSDK', '3.6.7'
+ pod 'OsanoConsentManagerSDK', '3.6.9'
 end
 ```


### PR DESCRIPTION
This pull request updates the Osano Consent Manager SDK to version 3.6.9 across the project. The main changes include updating the SDK version in dependency files and documentation to ensure consistency and provide users with the latest release.

Dependency updates:

* Updated the binary target in `Package.swift` to use version 3.6.9 of the `ConsentSDK` with the new download URL and checksum.
* Added a new `OsanoConsentManagerSDK.podspec` file for version 3.6.9, specifying the framework, deployment target, and metadata.

Documentation updates:

* Updated all references to the SDK version in `README.md` to `3.6.9`, including usage examples and sample `Podfile` entries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)