### PR TITLE
Version 3.6.10

### DIFF
--- a/OsanoConsentManagerSDK/3.6.10/OsanoConsentManagerSDK.podspec
+++ b/OsanoConsentManagerSDK/3.6.10/OsanoConsentManagerSDK.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'OsanoConsentManagerSDK'
+    s.version      = '3.6.10'
+    s.summary      = 'Osano Consent Manager SDK for iOS'
+    s.homepage     = 'https://osano.com'
+    s.license      = { :type => 'Copyright', :text => 'Copyright (C) Osano, Inc., a Public Benefit Corporation - All Rights Reserved'  }
+    s.author       = { 'Osano' => 'info@osano.com' }
+    s.source       = { :http => 'https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.10.zip' }
+    s.vendored_frameworks = 'ConsentSDK.xcframework'
+    s.platform = :ios
+    s.ios.deployment_target  = '12.1'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "ConsentSDK",
-            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.9.zip",
-            checksum: "ae50a5acdba1c76e7b2b67df778653a6f403b071e73e6d51c623c55b27b4e563"
+            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.10.zip",
+            checksum: "37b1ff8071137f6b46f32db7a8a6c4513eaa84098423fb6dad3cb6292af81bd7"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ source "https://github.com/osano/cocoapods-specs.git"
 Within your `target` add the `OsanoConsentManagerSDK` and version as a referenced pod.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '~> 3.6.9'
+pod 'OsanoConsentManagerSDK', '~> 3.6.10'
 ```
 
 By using a `~>` in front of your version number, you can automatically update to the most recently released major version. If you would rather specify your SDK version, omit the `~>` in front of the version number.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '3.6.9'
+pod 'OsanoConsentManagerSDK', '3.6.10'
 ```
 
 Your project's `Podfile` should look similar to the one below.
@@ -31,6 +31,6 @@ platform :ios, '12.1'
 source "https://github.com/osano/cocoapods-specs.git"
 target 'MyApp' do
  use_frameworks!
- pod 'OsanoConsentManagerSDK', '3.6.9'
+ pod 'OsanoConsentManagerSDK', '3.6.10'
 end
 ```


### PR DESCRIPTION
This pull request updates the Osano Consent Manager SDK to version 3.6.10 across the project. The main changes include updating version references and checksums in configuration files, adding a new podspec for CocoaPods support, and updating documentation to reflect the new version.

**SDK Version Update:**

* Updated the `ConsentSDK` binary target in `Package.swift` to use version 3.6.10 and its corresponding checksum.
* Added a new `OsanoConsentManagerSDK.podspec` file for version 3.6.10 to support CocoaPods integration.

**Documentation Update:**

* Updated all CocoaPods installation instructions in `README.md` to reference version 3.6.10 instead of 3.6.9. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)