### PR TITLE
[SDK-493] Version 3.6.11

### DIFF
--- a/OsanoConsentManagerSDK/3.6.11/OsanoConsentManagerSDK.podspec
+++ b/OsanoConsentManagerSDK/3.6.11/OsanoConsentManagerSDK.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'OsanoConsentManagerSDK'
+    s.version      = '3.6.11'
+    s.summary      = 'Osano Consent Manager SDK for iOS'
+    s.homepage     = 'https://osano.com'
+    s.license      = { :type => 'Copyright', :text => 'Copyright (C) Osano, Inc., a Public Benefit Corporation - All Rights Reserved'  }
+    s.author       = { 'Osano' => 'info@osano.com' }
+    s.source       = { :http => 'https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.11.zip' }
+    s.vendored_frameworks = 'ConsentSDK.xcframework'
+    s.platform = :ios
+    s.ios.deployment_target  = '12.1'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "ConsentSDK",
-            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.10.zip",
-            checksum: "37b1ff8071137f6b46f32db7a8a6c4513eaa84098423fb6dad3cb6292af81bd7"
+            url: "https://libraries.osano.com/ios/OsanoConsentManagerSDK/OsanoConsentManagerSDK-3.6.11.zip",
+            checksum: "47ddab716d14fda3139e65e53f595d2fb9e30606efa54284df1355b3625e5c97"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ source "https://github.com/osano/cocoapods-specs.git"
 Within your `target` add the `OsanoConsentManagerSDK` and version as a referenced pod.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '~> 3.6.10'
+pod 'OsanoConsentManagerSDK', '~> 3.6.11'
 ```
 
 By using a `~>` in front of your version number, you can automatically update to the most recently released major version. If you would rather specify your SDK version, omit the `~>` in front of the version number.
 
 ```Ruby
-pod 'OsanoConsentManagerSDK', '3.6.10'
+pod 'OsanoConsentManagerSDK', '3.6.11'
 ```
 
 Your project's `Podfile` should look similar to the one below.
@@ -31,6 +31,6 @@ platform :ios, '12.1'
 source "https://github.com/osano/cocoapods-specs.git"
 target 'MyApp' do
  use_frameworks!
- pod 'OsanoConsentManagerSDK', '3.6.10'
+ pod 'OsanoConsentManagerSDK', '3.6.11'
 end
 ```


### PR DESCRIPTION
This pull request updates the Osano Consent Manager SDK to version 3.6.11 across the project. The main changes ensure that both CocoaPods and Swift Package Manager integrations use the latest SDK version, and the documentation is updated accordingly.

SDK Version Update:

* Updated the `ConsentSDK` binary target in `Package.swift` to use version 3.6.11, including the new download URL and checksum.
* Added a new `OsanoConsentManagerSDK.podspec` for version 3.6.11, specifying all relevant metadata and dependencies.

Documentation:

* Updated `README.md` to reference version 3.6.11 in all CocoaPods installation instructions and sample `Podfile` snippets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)